### PR TITLE
Fix program and lock

### DIFF
--- a/coqpyt/coq/context.py
+++ b/coqpyt/coq/context.py
@@ -428,6 +428,24 @@ class FileContext:
             return self.__expr(step.ast.span["v"]["expr"])
         return [None]
 
+    def attrs(self, step: Step) -> List:
+        """
+        Args:
+            step (Step): The step to be processed.
+
+        Returns:
+            List: 'attrs' field from the AST of a step.
+        """
+        if (
+            step.ast.span is not None
+            and isinstance(step.ast.span, dict)
+            and "v" in step.ast.span
+            and isinstance(step.ast.span["v"], dict)
+            and "attrs" in step.ast.span["v"]
+        ):
+            return step.ast.span["v"]["attrs"]
+        return []
+
     def term_type(self, step: Step) -> TermType:
         """
         Args:

--- a/coqpyt/lsp/endpoint.py
+++ b/coqpyt/lsp/endpoint.py
@@ -104,6 +104,7 @@ class LspEndpoint(threading.Thread):
         cond.acquire()
         self.send_message(method_name, kwargs, current_id)
         if self.shutdown_flag:
+            cond.release()
             return None
         if not cond.wait(timeout=self.timeout):
             raise TimeoutError()

--- a/coqpyt/tests/proof_file/test_changes.py
+++ b/coqpyt/tests/proof_file/test_changes.py
@@ -538,10 +538,10 @@ class TestProofChangeObligation(SetupProofFile):
             "Next Obligation.",
         ]
         programs = [
-            ("id", "pred (S n)"),
-            ("id", "S (pred n)"),
-            ("id", "S (pred n)"),
-            ("idx", "pred (S n)"),
+            ("#[program]", "id", "pred (S n)"),
+            ("Program", "id", "S (pred n)"),
+            ("Program", "id", "S (pred n)"),
+            ("Program", "idx", "pred (S n)"),
         ]
 
         # Steps were added to the end of the file
@@ -555,10 +555,11 @@ class TestProofChangeObligation(SetupProofFile):
             assert proof.program is not None
             assert (
                 proof.program.text
-                == "Program Definition "
-                + programs[i][0]
-                + " (n : nat) : { x : nat | x = n } := if dec (Nat.leb n 0) then 0%nat else "
+                == programs[i][0]
+                + " Definition "
                 + programs[i][1]
+                + " (n : nat) : { x : nat | x = n } := if dec (Nat.leb n 0) then 0%nat else "
+                + programs[i][2]
                 + "."
             )
             assert len(proof.steps) == 2
@@ -577,10 +578,11 @@ class TestProofChangeObligation(SetupProofFile):
             assert proof.program is not None
             assert (
                 proof.program.text
-                == "Program Definition "
-                + programs[i][0]
-                + " (n : nat) : { x : nat | x = n } := if dec (Nat.leb n 0) then 0%nat else "
+                == programs[i][0]
+                + " Definition "
                 + programs[i][1]
+                + " (n : nat) : { x : nat | x = n } := if dec (Nat.leb n 0) then 0%nat else "
+                + programs[i][2]
                 + "."
             )
             assert len(proof.steps) == 2

--- a/coqpyt/tests/proof_file/test_proof_file.py
+++ b/coqpyt/tests/proof_file/test_proof_file.py
@@ -231,10 +231,10 @@ class TestProofObligation(SetupProofFile):
             ('Notation "x = y" := (eq x y) : type_scope.', TermType.NOTATION, []),
         ]
         texts = [
-            "Obligation 2 of id1.",
-            "Next Obligation of id1.",
-            "Obligation 2 of id2 : type with reflexivity.",
-            "Next Obligation of id2 with reflexivity.",
+            "Obligation 2 of id2.",
+            "Next Obligation of id2.",
+            "Obligation 2 of id3 : type with reflexivity.",
+            "Next Obligation of id3 with reflexivity.",
             "Next Obligation.",
             "Next Obligation with reflexivity.",
             "Obligation 1.",
@@ -244,17 +244,17 @@ class TestProofObligation(SetupProofFile):
             "Obligation 2 : type.",
         ]
         programs = [
-            ("id1", "S (pred n)"),
-            ("id1", "S (pred n)"),
-            ("id2", "S (pred n)"),
-            ("id2", "S (pred n)"),
-            ("id3", "S (pred n)"),
-            ("id3", "S (pred n)"),
-            ("id4", "S (pred n)"),
-            ("id4", "S (pred n)"),
-            ("id", "pred (S n)"),
-            ("id", "S (pred n)"),
-            ("id", "S (pred n)"),
+            ("#[global, program]", "id2", "S (pred n)"),
+            ("#[global, program]", "id2", "S (pred n)"),
+            ("Local Program", "id3", "S (pred n)"),
+            ("Local Program", "id3", "S (pred n)"),
+            ("#[local, program]", "id1", "S (pred n)"),
+            ("#[local, program]", "id1", "S (pred n)"),
+            ("Global Program", "id4", "S (pred n)"),
+            ("Global Program", "id4", "S (pred n)"),
+            ("#[program]", "id", "pred (S n)"),
+            ("Program", "id", "S (pred n)"),
+            ("Program", "id", "S (pred n)"),
         ]
 
         for i, proof in enumerate(proofs):
@@ -263,10 +263,11 @@ class TestProofObligation(SetupProofFile):
             assert proof.program is not None
             assert (
                 proof.program.text
-                == "Program Definition "
-                + programs[i][0]
-                + " (n : nat) : { x : nat | x = n } := if dec (Nat.leb n 0) then 0%nat else "
+                == programs[i][0]
+                + " Definition "
                 + programs[i][1]
+                + " (n : nat) : { x : nat | x = n } := if dec (Nat.leb n 0) then 0%nat else "
+                + programs[i][2]
                 + "."
             )
             assert len(proof.steps) == 2

--- a/coqpyt/tests/resources/test_obligation.v
+++ b/coqpyt/tests/resources/test_obligation.v
@@ -4,29 +4,31 @@ Ltac dummy_tactic n e := destruct n; try reflexivity; inversion e.
 
 Module TestObligations.
 
-Program Definition id1 (n : nat) : { x : nat | x = n } :=
+Global Program Definition id4 (n : nat) : { x : nat | x = n } :=
   if dec (Nat.leb n 0) then 0%nat
   else S (pred n).
-Program Definition id2 (n : nat) : { x : nat | x = n } :=
+Local Program Definition id3 (n : nat) : { x : nat | x = n } :=
   if dec (Nat.leb n 0) then 0%nat
   else S (pred n).
-Program Definition id3 (n : nat) : { x : nat | x = n } :=
+#[global, program]
+Definition id2 (n : nat) : { x : nat | x = n } :=
   if dec (Nat.leb n 0) then 0%nat
   else S (pred n).
-Program Definition id4 (n : nat) : { x : nat | x = n } :=
+#[local, program]
+Definition id1 (n : nat) : { x : nat | x = n } :=
   if dec (Nat.leb n 0) then 0%nat
   else S (pred n).
 
-Obligation 2 of id1.
+Obligation 2 of id2.
   dummy_tactic n e.
 Qed.
-Next Obligation of id1.
+Next Obligation of id2.
   dummy_tactic n e.
 Qed.
-Obligation 2 of id2 : type with reflexivity.
+Obligation 2 of id3 : type with reflexivity.
   dummy_tactic n e.
 Qed.
-Next Obligation of id2 with reflexivity.
+Next Obligation of id3 with reflexivity.
   dummy_tactic n e.
 Qed.
 Next Obligation.
@@ -51,7 +53,8 @@ Program Definition id (n : nat) : { x : nat | x = n } :=
   else S (pred n).
 
 Module In.
-Program Definition id (n : nat) : { x : nat | x = n } :=
+#[program]
+Definition id (n : nat) : { x : nat | x = n } :=
   if dec (Nat.leb n 0) then 0%nat
   else pred (S n).
 Obligation 1 of id with reflexivity.


### PR DESCRIPTION
- Detect if command is a program via AST, instead of "Program" substring.
- Iterate over programs in scope (instead of considering only the last one) to check which is the new program.
- Fix a deadlock which caused to program to not exit, even after calling `shutdown` and `exit`.