### PR TITLE
Better performance by using the delay option of coq-lsp. Improve performance of GH-Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: |
-          /home/runner/.opam
+          /home/runner/work/coqpyt/coqpyt/_opam/
         key: ${{ matrix.ocaml-compiler }}-${{ matrix.coq-version }}-opam
 
     - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
@@ -65,5 +65,5 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: |
-          /home/runner/.opam
+          /home/runner/work/coqpyt/coqpyt/_opam/
         key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         path: |
           /home/runner/.opam
-        key: ${{ matrix.ocaml-compiler }}-${{ coq-version }}-opam
+        key: ${{ matrix.ocaml-compiler }}-${{ matrix.coq-version }}-opam
 
     - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         ocaml-compiler:
           - "4.11"
+        coq-version:
+          - "8.19.1"
 
     steps:
     - name: Checkout
@@ -28,13 +30,24 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Restore opam
+      id: cache-opam-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          /home/runner/.opam
+        key: ${{ matrix.ocaml-compiler }}-${{ coq-version }}-opam
+
     - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
     - name: Install coq-lsp
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       run: |
+        opam pin add coq ${{ matrix.coq-version }}
         opam install coq-lsp
 
     - name: Install coqpyt
@@ -46,3 +59,11 @@ jobs:
         eval $(opam env)
         cd coqpyt
         pytest tests -s
+
+    - name: Save opam
+      id: cache-opam-save
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          /home/runner/.opam
+        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
         key: ${{ matrix.ocaml-compiler }}-${{ matrix.coq-version }}-opam
 
     - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
         ocaml-compiler:
           - "4.11"
         coq-version:
+          - "8.17.1"
+          - "8.18.0"
           - "8.19.1"
 
     steps:

--- a/coqpyt/coq/context.py
+++ b/coqpyt/coq/context.py
@@ -27,13 +27,13 @@ class FileContext:
 
         # For versions 8.18+, we ignore the tags [VernacSynterp] and [VernacSynPure]
         # and use the "ntn_decl" prefix when handling where notations
-        post17 = version.parse(coq_version) > version.parse("8.17")
+        post17 = version.parse(coq_version) >= version.parse("8.18")
         self.__expr = lambda e: e[1] if post17 else e
         self.__where_notation_key = "ntn_decl" if post17 else "decl_ntn"
 
         # For versions 8.19+, VernacExtend has a dictionary instead of a list in the
         # AST, so we use "ext_plugin","ext_entry" and "ext_index" instead of indices
-        post18 = version.parse(coq_version) > version.parse("8.18")
+        post18 = version.parse(coq_version) >= version.parse("8.19")
         self.__ext_plugin = lambda e: e["ext_plugin"] if post18 else None
         self.__ext_entry = lambda e: e["ext_entry"] if post18 else e[0]
         # FIXME: This should be made private once [__get_program_context] is extracted

--- a/coqpyt/coq/lsp/client.py
+++ b/coqpyt/coq/lsp/client.py
@@ -30,6 +30,7 @@ class CoqLspClient(LspClient):
         timeout: int = 30,
         memory_limit: int = 2097152,
         coq_lsp: str = "coq-lsp",
+        coq_lsp_options: str = "-D 0",
         init_options: Dict = __DEFAULT_INIT_OPTIONS,
     ):
         """Creates a CoqLspClient
@@ -61,9 +62,9 @@ class CoqLspClient(LspClient):
         self.file_progress: Dict[str, List[CoqFileProgressParams]] = {}
 
         if sys.platform.startswith("linux"):
-            command = f"ulimit -v {memory_limit}; {coq_lsp}"
+            command = f"ulimit -v {memory_limit}; {coq_lsp} {coq_lsp_options}"
         else:
-            command = coq_lsp
+            command = f"{coq_lsp} {coq_lsp_options}"
 
         proc = subprocess.Popen(
             command,

--- a/coqpyt/tests/proof_file/expected/imports.yml
+++ b/coqpyt/tests/proof_file/expected/imports.yml
@@ -167,7 +167,7 @@ proofs:
             line: 21
             character: 0
     context:
-      - "8.19.0":
+      - "8.19.x":
           text: "Notation \"∀ x .. y , P\" := (forall x, .. (forall y, P) ..) (at level 10, x binder, y binder, P at level 200, format \"'[ ' '[ ' ∀ x .. y ']' , '/' P ']'\") : type_scope."
           type: NOTATION
         default:

--- a/coqpyt/tests/proof_file/expected/valid_file.yml
+++ b/coqpyt/tests/proof_file/expected/valid_file.yml
@@ -198,7 +198,7 @@ proofs:
             line: 26
             character: 10
     context:
-      - "8.19.0":
+      - "8.19.x":
           text: "Notation \"∀ x .. y , P\" := (forall x, .. (forall y, P) ..) (at level 10, x binder, y binder, P at level 200, format \"'[ ' '[ ' ∀ x .. y ']' , '/' P ']'\") : type_scope."
           type: NOTATION
         default:
@@ -364,7 +364,7 @@ proofs:
             line: 51
             character: 4
     context:
-      - "8.19.0":
+      - "8.19.x":
           text: "Notation \"∀ x .. y , P\" := (forall x, .. (forall y, P) ..) (at level 10, x binder, y binder, P at level 200, format \"'[ ' '[ ' ∀ x .. y ']' , '/' P ']'\") : type_scope."
           type: NOTATION
         default:


### PR DESCRIPTION
Our unit tests got a speed-up of around 2.25 with this option. Thanks @rkthomps
Now we also use a cache for the GH-Actions CI workflow.