### PR TITLE
Add caching on disk

### DIFF
--- a/coqpyt/tests/proof_file/test_cache.py
+++ b/coqpyt/tests/proof_file/test_cache.py
@@ -1,0 +1,37 @@
+from utility import *
+
+
+class TestCache(SetupProofFile):
+    def setup_method(self, method):
+        self.setup(
+            "test_imports/test_import.v",
+            workspace="test_imports/",
+            use_disk_cache=False,
+        )
+        self.no_cache_terms = self.proof_file.context.terms.copy()
+        self.no_cache_libs = self.proof_file.context.libraries.copy()
+        self.teardown_method(method)
+
+        self.setup(
+            "test_imports/test_import.v",
+            workspace="test_imports/",
+            use_disk_cache=True,
+        )
+        self.cache1_terms = self.proof_file.context.terms.copy()
+        self.cache1_libs = self.proof_file.context.libraries.copy()
+        self.teardown_method(method)
+
+        self.setup(
+            "test_imports/test_import.v",
+            workspace="test_imports/",
+            use_disk_cache=True,
+        )
+        self.cache2_terms = self.proof_file.context.terms.copy()
+        self.cache2_libs = self.proof_file.context.libraries.copy()
+
+    def test_cache(self):
+        assert self.no_cache_terms == self.cache1_terms
+        assert self.cache1_terms == self.cache2_terms
+
+        assert self.no_cache_libs == self.cache1_libs
+        assert self.cache1_libs == self.cache2_libs

--- a/coqpyt/tests/proof_file/utility.py
+++ b/coqpyt/tests/proof_file/utility.py
@@ -15,7 +15,7 @@ from coqpyt.coq.lsp.structs import *
 
 
 class SetupProofFile(ABC):
-    def setup(self, file_path, workspace=None):
+    def setup(self, file_path, workspace=None, use_disk_cache: bool = False):
         if workspace is not None:
             self.workspace = os.path.join(
                 tempfile.gettempdir(), "test" + str(uuid.uuid4()).replace("-", "")
@@ -37,7 +37,10 @@ class SetupProofFile(ABC):
 
         uri = "file://" + self.file_path
         self.proof_file = ProofFile(
-            self.file_path, timeout=60, workspace=self.workspace
+            self.file_path,
+            timeout=60,
+            workspace=self.workspace,
+            use_disk_cache=use_disk_cache,
         )
         self.proof_file.run()
         self.versionId = VersionedTextDocumentIdentifier(uri, 1)


### PR DESCRIPTION
Start thinking about caching file context on disk so that cached proof files are available across processes. Here are the possible issues with this implementation:
- Only depends on the "libraries hash". Does not depend on CoqPyt version or Coq version.
- Hash does not take into account file dependencies. Not sure if that affects correctness. 

With that being said this significantly speeds up time for ProofFiles. 
For example, the tests go from 94s to 55s on subsequent runs. 
Time to run a Proof File for Sudoku.v in the Sudoku repo goes from 199s to 33s. 

I think this is important since many files share dependencies even if they are in different projects. 