### PR TITLE
Program w/o obligations, goal_after_tactic and fixes

### DIFF
--- a/coqpyt/coq/base_file.py
+++ b/coqpyt/coq/base_file.py
@@ -259,8 +259,8 @@ class CoqFile(object):
         start_line = lines[prev_step_end.line]
         end_line = lines[step.ast.range.end.line]
 
-        start_line = start_line[: prev_step_end.character]
         end_line = end_line[step.ast.range.end.character :]
+        start_line = start_line[: prev_step_end.character]
 
         if prev_step_end.line == step.ast.range.end.line:
             lines[prev_step_end.line] = start_line + end_line
@@ -303,17 +303,20 @@ class CoqFile(object):
 
         deleted_lines = deleted_step.text.count("\n")
         last_line_chars = deleted_step.ast.range.end.character
+        last_line_offset = 0
         if deleted_step.ast.range.start.line == prev_step_end.line:
             last_line_chars -= prev_step_end.character
+        else:
+            last_line_offset = prev_step_end.character
 
         for step in self.steps[step_index:]:
             step.ast.range.start.line -= deleted_lines
             step.ast.range.end.line -= deleted_lines
 
             if step.ast.range.start.line == deleted_step.ast.range.end.line:
-                step.ast.range.start.character -= last_line_chars
+                step.ast.range.start.character -= last_line_chars - last_line_offset
             if step.ast.range.end.line == deleted_step.ast.range.end.line:
-                step.ast.range.end.character -= last_line_chars
+                step.ast.range.end.character -= last_line_chars - last_line_offset
 
     def __add_update_ast(self, previous_step_index: int, step_text: str) -> Step:
         prev_step_end = self.steps[previous_step_index].ast.range.end

--- a/coqpyt/coq/lsp/client.py
+++ b/coqpyt/coq/lsp/client.py
@@ -21,6 +21,7 @@ class CoqLspClient(LspClient):
 
     __DEFAULT_INIT_OPTIONS = {
         "max_errors": 120000000,
+        "goal_after_tactic": False,
         "show_coq_info_messages": True,
     }
 

--- a/coqpyt/coq/proof_file.py
+++ b/coqpyt/coq/proof_file.py
@@ -990,7 +990,7 @@ class ProofFile(CoqFile):
         if processed:
             n_steps = self.steps_taken - previous_step_index - 2
             self.__local_exec(-n_steps)  # Backtrack until added step
-            self._step(-1) # Ignore added step while backtracking
+            self._step(-1)  # Ignore added step while backtracking
             self.__local_exec()  # Execute added step
             self.__add_step(previous_step_index + 1)
             self.__local_exec(n_steps)  # Execute until starting point

--- a/coqpyt/tests/proof_file/test_proof_file.py
+++ b/coqpyt/tests/proof_file/test_proof_file.py
@@ -295,7 +295,7 @@ class TestProofObligation(SetupProofFile):
                 "Program Definition id (n : nat) : { x : nat | x = n } := if dec (Nat.leb n 0) then 0%nat else S (pred n).",
                 TermType.DEFINITION,
                 ["Out"],
-            )
+            ),
         ]
         texts = [
             "Program Lemma id_lemma (n : nat) : id n = n.",

--- a/coqpyt/tests/resources/test_obligation.v
+++ b/coqpyt/tests/resources/test_obligation.v
@@ -52,6 +52,11 @@ Program Definition id (n : nat) : { x : nat | x = n } :=
   if dec (Nat.leb n 0) then 0%nat
   else S (pred n).
 
+Program Lemma id_lemma (n : nat) : id n = n.
+Proof. destruct n; try reflexivity. Qed.
+Program Theorem id_theorem (n : nat) : id n = n.
+Proof. destruct n; try reflexivity. Qed.
+
 Module In.
 #[program]
 Definition id (n : nat) : { x : nat | x = n } :=


### PR DESCRIPTION
- Add support for Program commands that enter proof mode directly instead of generating obligations
- Set goal_after_tactic option in coq-lsp to false by default
- Fix updates to the AST when deleting steps in a CoqFile