### PR TITLE
Adhoc handling of custom entries for notations and improvements on plugins (VernacExtend)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         ocaml-compiler:
-          - "4.11"
+          - "5.2.0"
         coq-version:
           - "8.17.1"
           - "8.18.0"
-          - "8.19.1"
+          - "8.19.2"
 
     steps:
     - name: Checkout
@@ -40,8 +40,8 @@ jobs:
           /home/runner/work/coqpyt/coqpyt/_opam/
         key: ${{ matrix.ocaml-compiler }}-${{ matrix.coq-version }}-opam
 
-    - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
-      uses: ocaml/setup-ocaml@v2
+    - name: Set-up OCaml
+      uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,11 @@ jobs:
         opam pin add coq ${{ matrix.coq-version }}
         opam install coq-lsp
 
+    - name: Install coq-equations
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      run: |
+        opam install coq-equations
+
     - name: Install coqpyt
       run: |
         pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,11 @@ jobs:
         opam pin add coq ${{ matrix.coq-version }}
         opam install coq-lsp
 
+    - name: Add coq-released
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      run: |
+        opam repo add coq-released https://coq.inria.fr/opam/released
+
     - name: Install coq-equations
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       run: |

--- a/coqpyt/coq/context.py
+++ b/coqpyt/coq/context.py
@@ -111,7 +111,9 @@ class FileContext:
                 name = FileContext.get_ident(arg)
                 if name is not None:
                     self.__add_term(name, step, term_type)
-        elif term_type == TermType.OBLIGATION:
+        elif term_type in [TermType.OBLIGATION, TermType.EQUATION]:
+            # FIXME: For Equations, we are unable of getting terms from the AST
+            # but these commands do generate named terms
             self.__last_terms[-1].append(
                 ("", Term(step, term_type, self.__path, self.__segments.modules[:]))
             )

--- a/coqpyt/coq/context.py
+++ b/coqpyt/coq/context.py
@@ -320,16 +320,11 @@ class FileContext:
         # FIXME: This method should be made private once [__get_program_context]
         # is extracted from ProofFile to here.
         def handle_arg_type(args, ids):
-            # FIXME: Other options for arg[0] are "OptArg" and "PairArg".
             if args[0] == "ExtraArg":
                 if args[1] == "identref":
                     return ids[0][1][1]
                 elif args[1] == "ident":
                     return ids[1]
-            elif args[0] == "ListArg" and len(ids) > 0:
-                # FIXME: This recursive case works when the list is of length 1,
-                # but it should be generalized to handle any length.
-                return handle_arg_type(args[1], ids[0])
             return None
 
         if len(el) == 3 and el[0] == "GenArg" and el[1][0] == "Rawwit":

--- a/coqpyt/coq/context.py
+++ b/coqpyt/coq/context.py
@@ -326,7 +326,7 @@ class FileContext:
                     return ids[0][1][1]
                 elif args[1] == "ident":
                     return ids[1]
-            elif args[0] == "ListArg":
+            elif args[0] == "ListArg" and len(ids) > 0:
                 # FIXME: This recursive case works when the list is of length 1,
                 # but it should be generalized to handle any length.
                 return handle_arg_type(args[1], ids[0])

--- a/coqpyt/coq/structs.py
+++ b/coqpyt/coq/structs.py
@@ -36,6 +36,7 @@ class TermType(Enum):
     SETOID = 22
     FUNCTION = 23
     DERIVE = 24
+    EQUATION = 25
     OTHER = 100
 
 

--- a/coqpyt/tests/proof_file/test_proof_file.py
+++ b/coqpyt/tests/proof_file/test_proof_file.py
@@ -120,6 +120,28 @@ class TestProofUnknownNotation(SetupProofFile):
             assert self.proof_file.context.get_notation("{ _ }", "")
 
 
+class TestProofNthLocate(SetupProofFile):
+    def setup_method(self, method):
+        self.setup("test_nth_locate.v")
+
+    def test_nth_locate(self):
+        """Checks if it is able to handle notations that are not the first result
+        returned by the Locate command.
+        """
+        proof_file = self.proof_file
+        assert len(proof_file.proofs) == 1
+        proof = proof_file.proofs[0]
+
+        theorem = "Lemma test : <> = <>."
+        assert proof.text == theorem
+
+        statement_context = [
+            ('Notation "x = y" := (eq x y) : type_scope.', TermType.NOTATION, []),
+            ('Notation "<>" := BAnon : binder_scope.', TermType.NOTATION, []),
+        ]
+        compare_context(statement_context, proof.context)
+
+
 class TestProofNestedProofs(SetupProofFile):
     def setup_method(self, method):
         self.setup("test_nested_proofs.v")

--- a/coqpyt/tests/resources/test_equations.v
+++ b/coqpyt/tests/resources/test_equations.v
@@ -1,0 +1,6 @@
+From Equations Require Import Equations.
+
+Equations? f (n : nat) : nat :=
+  f 0 := 42 ;
+  f (S m) with f m := { f (S m) IH := _ }.
+Proof. intros. exact IH. Defined.

--- a/coqpyt/tests/resources/test_nth_locate.v
+++ b/coqpyt/tests/resources/test_nth_locate.v
@@ -1,0 +1,7 @@
+Inductive binder := BAnon | BNum :> nat -> binder.
+Declare Scope binder_scope.
+Notation "<>" := BAnon : binder_scope.
+
+Open Scope binder_scope.
+Lemma test : <> = <>.
+Proof. reflexivity. Qed.

--- a/coqpyt/tests/test_coq_file.py
+++ b/coqpyt/tests/test_coq_file.py
@@ -280,6 +280,17 @@ def test_derive(setup, teardown):
         )
 
 
+@pytest.mark.parametrize("setup", ["test_equations.v"], indirect=True)
+def test_derive(setup, teardown):
+    coq_file.run()
+    assert len(coq_file.context.terms) == 0
+    assert coq_file.context.last_term is not None
+    assert (
+        coq_file.context.last_term.text
+        == "Equations? f (n : nat) : nat := f 0 := 42 ; f (S m) with f m := { f (S m) IH := _ }."
+    )
+
+
 def test_space_in_path():
     # This test exists because coq-lsp encodes spaces in paths as %20
     # This causes the diagnostics to be saved in a different path than the one


### PR DESCRIPTION
- To handle InCustomEntry from the AST, only consider notations with a non-empty pattern for the step context.
- A single notation might yield multiple `Locate` results. We now iterate over all, instead of just trying the first one.
- ~AST nodes with `GenArg` now (partially) support `ListArg`, besides `ExtraArg`.~
- Plugin for [Coq-Equations](https://github.com/mattam82/Coq-Equations/tree/main) is now recognized by `FileContext`.