### PR TITLE
Partial handling of aborted proofs

### DIFF
--- a/coqpyt/coq/context.py
+++ b/coqpyt/coq/context.py
@@ -489,9 +489,60 @@ class FileContext:
             step (Step): The step to be processed.
 
         Returns:
-            List: The term type of the step.
+            TermType: The term type of the step.
         """
         return self.__term_type(self.expr(step))
+
+    def is_proof_term(self, step: Step) -> bool:
+        """
+        Args:
+            step (Step): The step to be processed.
+
+        Returns:
+            bool: Whether the step introduces a new proof term.
+        """
+        term_type = self.term_type(step)
+        # Assume that terms of the following types do not introduce new proofs
+        # FIXME: Should probably check if goals were changed
+        return term_type not in [
+            TermType.TACTIC,
+            TermType.NOTATION,
+            TermType.INDUCTIVE,
+            TermType.COINDUCTIVE,
+            TermType.RECORD,
+            TermType.CLASS,
+            TermType.SCHEME,
+            TermType.VARIANT,
+            TermType.OTHER,
+        ]
+
+    def is_end_proof(self, step: Step) -> bool:
+        """
+        Args:
+            step (Step): The step to be processed.
+
+        Returns:
+            bool: Whether the step closes an open proof term.
+        """
+        # FIXME: Refer to issue #55: https://github.com/sr-lab/coqpyt/issues/55
+        expr = self.expr(step)[0]
+        return expr in ["VernacEndProof", "VernacExactProof", "VernacAbort"]
+
+    def is_segment_delimiter(self, step: Step) -> bool:
+        """
+        Args:
+            step (Step): The step to be processed.
+
+        Returns:
+            bool: Whether the step delimits a segment (module or section).
+        """
+        expr = self.expr(step)[0]
+        return expr in [
+            "VernacEndSegment",
+            "VernacDefineModule",
+            "VernacDeclareModuleType",
+            "VernacBeginSection",
+        ]
 
     def update(self, context: Union["FileContext", Dict[str, Term]] = {}):
         """Updates the context with new terms.

--- a/coqpyt/tests/proof_file/expected/valid_file.yml
+++ b/coqpyt/tests/proof_file/expected/valid_file.yml
@@ -185,7 +185,7 @@ proofs:
           end:
             line: 25
             character: 16
-      - text: "\n  Defined."
+      - text: "\n  Abort."
         goals:
           position:
             line: 26
@@ -196,7 +196,7 @@ proofs:
             character: 2
           end:
             line: 26
-            character: 10
+            character: 8
     context:
       - "8.19.x":
           text: "Notation \"∀ x .. y , P\" := (forall x, .. (forall y, P) ..) (at level 10, x binder, y binder, P at level 200, format \"'[ ' '[ ' ∀ x .. y ']' , '/' P ']'\") : type_scope."
@@ -275,7 +275,7 @@ proofs:
         context:
           - text: "Ltac reduce_eq := simpl; reflexivity."
             type: TACTIC
-      - text: "\n    Qed."
+      - text: "\n    Defined."
         goals:
           position:
             line: 38

--- a/coqpyt/tests/resources/test_valid.v
+++ b/coqpyt/tests/resources/test_valid.v
@@ -24,7 +24,7 @@ Section Random.
     rewrite -> (plus_O_n (S n * m)).
     Compute True /\ True.
     reflexivity.
-  Defined.
+  Abort.
 End Random.
 
 Module Extra.
@@ -36,7 +36,7 @@ Module Extra.
       Compute mk_example n n.
       Compute Out.In.plus_O_n.
       reduce_eq.
-    Qed.
+    Defined.
   End Fst.
 
   Module Snd.


### PR DESCRIPTION
`Abort` commands are now recognized by CoqPyt as proof-ending commands.